### PR TITLE
Remove /discord if the invite link isn't valid

### DIFF
--- a/src/main/java/onebeastchris/util/Register.java
+++ b/src/main/java/onebeastchris/util/Register.java
@@ -18,7 +18,10 @@ public class Register {
         ServerLeaveEvent.register();
         Timer.register();
         if (visitors.config.getDiscordCommand()) {
-            registerCommand();
+            // if the "inviteLink" value is beginning with https://discord.gg OR https://discord.com/invite
+            if (visitors.config.getInviteLink().startsWith("https://discord.gg") || visitors.config.getInviteLink().startsWith("https://discord.com/invite")) {
+                registerCommand();
+            }
         }
     }
 }

--- a/src/main/java/onebeastchris/util/Register.java
+++ b/src/main/java/onebeastchris/util/Register.java
@@ -18,8 +18,8 @@ public class Register {
         ServerLeaveEvent.register();
         Timer.register();
         if (visitors.config.getDiscordCommand()) {
-            // if the "inviteLink" value is beginning with https://discord.gg OR https://discord.com/invite
-            if (visitors.config.getInviteLink().startsWith("https://discord.gg") || visitors.config.getInviteLink().startsWith("https://discord.com/invite")) {
+            // if the "inviteLink" value is not default and if "discordCommand" is true
+            if (!visitors.config.getInviteLink().equals("https://discord.gg/INVITE_LINK") && visitors.config.getDiscordCommand()) {
                 registerCommand();
             }
         }

--- a/src/main/java/onebeastchris/util/Register.java
+++ b/src/main/java/onebeastchris/util/Register.java
@@ -17,11 +17,8 @@ public class Register {
         ServerJoinEvent.register();
         ServerLeaveEvent.register();
         Timer.register();
-        if (visitors.config.getDiscordCommand()) {
-            // if the "inviteLink" value is not default and if "discordCommand" is true
-            if (!visitors.config.getInviteLink().equals("https://discord.gg/INVITE_LINK") && visitors.config.getDiscordCommand()) {
-                registerCommand();
-            }
+        if (!visitors.config.getInviteLink().equals("https://discord.gg/INVITE_LINK") && visitors.config.getDiscordCommand()) {
+            registerCommand();
         }
     }
 }


### PR DESCRIPTION
Simple fork to not register the `/discord` command if the invite link does not start with https://discord.gg or with https://discord.com/invite